### PR TITLE
feat(frontend): research theme listing for candidates

### DIFF
--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -28,6 +28,8 @@ function getHeaderNavItems(role: string | null): HeaderNavItem[] {
   if (role && MANAGEMENT_ROLES.has(role)) {
     items.push({ label: 'Gestao de docentes', to: '/manage/professors' });
     items.push({ label: 'Gestao de temas', to: '/manage/research-themes' });
+  } else {
+    items.push({ label: 'Temas de Pesquisa', to: '/research-themes' });
   }
 
   return items;

--- a/frontend/src/features/research-themes/components/ResearchThemesListing.tsx
+++ b/frontend/src/features/research-themes/components/ResearchThemesListing.tsx
@@ -1,0 +1,197 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import * as React from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useDebounce } from '@/hooks/use-debounce';
+import { api } from '@/lib/api';
+import { formatNumberPtBr } from '@/lib/formatters';
+
+interface Props {
+  page: number;
+  search: string;
+  level: 'all' | 'masters' | 'doctoral';
+}
+
+export function ResearchThemesListing({ page, search, level }: Props) {
+  const navigate = useNavigate();
+  const PAGE_SIZE = 10;
+
+  const [localSearch, setLocalSearch] = React.useState(search);
+  const debouncedSearch = useDebounce(localSearch, 300);
+
+  React.useEffect(() => {
+    setLocalSearch(search);
+  }, [search]);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['research-themes', page, PAGE_SIZE, debouncedSearch, level],
+    queryFn: () =>
+      api.researchThemes.findAll({
+        page,
+        limit: PAGE_SIZE,
+        search: debouncedSearch || undefined,
+        level: level === 'all' ? undefined : level,
+      }),
+  });
+
+  const themes = data?.data ?? [];
+  const total = data?.pagination.total ?? 0;
+  const totalPages = data?.pagination.totalPages ?? 1;
+
+  type SearchParams = { page: number; search: string; level: 'all' | 'masters' | 'doctoral' };
+
+  function pushSearch(patch: Partial<SearchParams>) {
+    void navigate({
+      to: '/research-themes',
+      search: prev => ({ ...prev, ...patch } as SearchParams),
+    });
+  }
+
+  return (
+    <div className="flex flex-col space-y-6">
+      <div className="space-y-1">
+        <h1 className="font-serif text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
+          Temas de Pesquisa
+        </h1>
+        <p className="text-sm text-slate-500">
+          Explore os temas de pesquisa disponíveis no programa de pós-graduação.
+        </p>
+      </div>
+
+      <Card className="rounded-3xl border-slate-200">
+        <CardContent className="p-4 sm:p-6">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="sm:col-span-2">
+              <Input
+                placeholder="Buscar por título ou nome do orientador..."
+                value={localSearch}
+                onChange={e => {
+                  setLocalSearch(e.target.value);
+                  pushSearch({ search: e.target.value, page: 1 });
+                }}
+                className="w-full"
+              />
+            </div>
+            <div>
+              <Select
+                value={level}
+                onValueChange={val => pushSearch({ level: val as 'all' | 'masters' | 'doctoral', page: 1 })}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Filtrar por nível" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos os Níveis</SelectItem>
+                  <SelectItem value="masters">Mestrado</SelectItem>
+                  <SelectItem value="doctoral">Doutorado</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="overflow-hidden rounded-3xl border-slate-200">
+        <CardHeader className="border-b border-slate-100 bg-slate-50/50 px-6 py-4">
+          <CardTitle className="text-sm font-semibold text-slate-900">
+            Temas Disponíveis ({total})
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="divide-y divide-slate-100 p-0">
+          {isLoading ? (
+            <div className="p-12 text-center text-sm text-slate-500">Carregando temas...</div>
+          ) : themes.length > 0 ? (
+            themes.map(theme => (
+              <div key={theme.id} className="p-6 transition-colors hover:bg-slate-50/50">
+                <div className="space-y-2.5">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-serif text-lg font-medium text-slate-900">{theme.title}</p>
+                    <Badge variant={theme.level === 'masters' ? 'default' : 'secondary'}>
+                      {theme.level === 'masters' ? 'Mestrado' : 'Doutorado'}
+                    </Badge>
+                    {theme.vacancies === 0 && (
+                      <Badge variant="destructive">Sem vagas</Badge>
+                    )}
+                  </div>
+
+                  <p className="line-clamp-3 text-sm text-slate-600">{theme.description}</p>
+
+                  <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-slate-500">
+                    <span>
+                      Orientador:{' '}
+                      <strong className="text-slate-800">
+                        {theme.professor
+                          ? `${theme.professor.firstName} ${theme.professor.lastName}`
+                          : 'Desconhecido'}
+                      </strong>
+                    </span>
+                    <span>
+                      Vagas:{' '}
+                      <strong className="text-slate-800">
+                        {formatNumberPtBr(theme.vacancies)}
+                      </strong>
+                    </span>
+                  </div>
+
+                  {theme.associatedProfessors && theme.associatedProfessors.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-1.5 pt-1">
+                      <span className="text-xs text-slate-400">Colaboradores:</span>
+                      {theme.associatedProfessors.map(p => (
+                        <Badge
+                          key={p.id}
+                          variant="outline"
+                          className="px-2 py-0 text-[10px] font-normal"
+                        >
+                          {p.firstName} {p.lastName}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="p-12 text-center text-sm text-slate-400">
+              Nenhum tema encontrado para os filtros aplicados.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-end space-x-2 py-4">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => pushSearch({ page: Math.max(1, page - 1) })}
+            disabled={page === 1}
+          >
+            Anterior
+          </Button>
+          <div className="text-xs text-slate-500">
+            Página {page} de {totalPages}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => pushSearch({ page: Math.min(totalPages, page + 1) })}
+            disabled={page === totalPages}
+          >
+            Próxima
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/research-themes/components/ResearchThemesListing.tsx
+++ b/frontend/src/features/research-themes/components/ResearchThemesListing.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import * as React from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -27,12 +26,7 @@ export function ResearchThemesListing({ page, search, level }: Props) {
   const navigate = useNavigate();
   const PAGE_SIZE = 10;
 
-  const [localSearch, setLocalSearch] = React.useState(search);
-  const debouncedSearch = useDebounce(localSearch, 300);
-
-  React.useEffect(() => {
-    setLocalSearch(search);
-  }, [search]);
+  const debouncedSearch = useDebounce(search, 300);
 
   const { data, isLoading } = useQuery({
     queryKey: ['research-themes', page, PAGE_SIZE, debouncedSearch, level],
@@ -54,7 +48,7 @@ export function ResearchThemesListing({ page, search, level }: Props) {
   function pushSearch(patch: Partial<SearchParams>) {
     void navigate({
       to: '/research-themes',
-      search: prev => ({ ...prev, ...patch } as SearchParams),
+      search: prev => ({ ...prev, ...patch }) as SearchParams,
     });
   }
 
@@ -75,18 +69,17 @@ export function ResearchThemesListing({ page, search, level }: Props) {
             <div className="sm:col-span-2">
               <Input
                 placeholder="Buscar por título ou nome do orientador..."
-                value={localSearch}
-                onChange={e => {
-                  setLocalSearch(e.target.value);
-                  pushSearch({ search: e.target.value, page: 1 });
-                }}
+                value={search}
+                onChange={e => pushSearch({ search: e.target.value, page: 1 })}
                 className="w-full"
               />
             </div>
             <div>
               <Select
                 value={level}
-                onValueChange={val => pushSearch({ level: val as 'all' | 'masters' | 'doctoral', page: 1 })}
+                onValueChange={val =>
+                  pushSearch({ level: val as 'all' | 'masters' | 'doctoral', page: 1 })
+                }
               >
                 <SelectTrigger>
                   <SelectValue placeholder="Filtrar por nível" />
@@ -120,9 +113,7 @@ export function ResearchThemesListing({ page, search, level }: Props) {
                     <Badge variant={theme.level === 'masters' ? 'default' : 'secondary'}>
                       {theme.level === 'masters' ? 'Mestrado' : 'Doutorado'}
                     </Badge>
-                    {theme.vacancies === 0 && (
-                      <Badge variant="destructive">Sem vagas</Badge>
-                    )}
+                    {theme.vacancies === 0 && <Badge variant="destructive">Sem vagas</Badge>}
                   </div>
 
                   <p className="line-clamp-3 text-sm text-slate-600">{theme.description}</p>

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as AuthForgotPasswordRouteImport } from './routes/auth/forgot-pas
 import { Route as AuthConfirmNewEmailRouteImport } from './routes/auth/confirm-new-email'
 import { Route as AuthConfirmEmailRouteImport } from './routes/auth/confirm-email'
 import { Route as AuthChangePasswordRouteImport } from './routes/auth/change-password'
+import { Route as AppResearchThemesRouteImport } from './routes/_app/research-themes'
 import { Route as AuthOnboardingIndexRouteImport } from './routes/auth/onboarding/index'
 import { Route as AuthOnboardingSecretaryRouteImport } from './routes/auth/onboarding/secretary'
 import { Route as AuthOnboardingProfessorRouteImport } from './routes/auth/onboarding/professor'
@@ -74,6 +75,11 @@ const AuthChangePasswordRoute = AuthChangePasswordRouteImport.update({
   path: '/change-password',
   getParentRoute: () => AuthRoute,
 } as any)
+const AppResearchThemesRoute = AppResearchThemesRouteImport.update({
+  id: '/research-themes',
+  path: '/research-themes',
+  getParentRoute: () => AppRoute,
+} as any)
 const AuthOnboardingIndexRoute = AuthOnboardingIndexRouteImport.update({
   id: '/onboarding/',
   path: '/onboarding/',
@@ -103,6 +109,7 @@ const AppManageProfessorsRoute = AppManageProfessorsRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof AppIndexRoute
   '/auth': typeof AuthRouteWithChildren
+  '/research-themes': typeof AppResearchThemesRoute
   '/auth/change-password': typeof AuthChangePasswordRoute
   '/auth/confirm-email': typeof AuthConfirmEmailRoute
   '/auth/confirm-new-email': typeof AuthConfirmNewEmailRoute
@@ -118,6 +125,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/auth': typeof AuthRouteWithChildren
+  '/research-themes': typeof AppResearchThemesRoute
   '/auth/change-password': typeof AuthChangePasswordRoute
   '/auth/confirm-email': typeof AuthConfirmEmailRoute
   '/auth/confirm-new-email': typeof AuthConfirmNewEmailRoute
@@ -136,6 +144,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_app': typeof AppRouteWithChildren
   '/auth': typeof AuthRouteWithChildren
+  '/_app/research-themes': typeof AppResearchThemesRoute
   '/auth/change-password': typeof AuthChangePasswordRoute
   '/auth/confirm-email': typeof AuthConfirmEmailRoute
   '/auth/confirm-new-email': typeof AuthConfirmNewEmailRoute
@@ -155,6 +164,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/auth'
+    | '/research-themes'
     | '/auth/change-password'
     | '/auth/confirm-email'
     | '/auth/confirm-new-email'
@@ -170,6 +180,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/auth'
+    | '/research-themes'
     | '/auth/change-password'
     | '/auth/confirm-email'
     | '/auth/confirm-new-email'
@@ -187,6 +198,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/_app'
     | '/auth'
+    | '/_app/research-themes'
     | '/auth/change-password'
     | '/auth/confirm-email'
     | '/auth/confirm-new-email'
@@ -279,6 +291,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthChangePasswordRouteImport
       parentRoute: typeof AuthRoute
     }
+    '/_app/research-themes': {
+      id: '/_app/research-themes'
+      path: '/research-themes'
+      fullPath: '/research-themes'
+      preLoaderRoute: typeof AppResearchThemesRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/auth/onboarding/': {
       id: '/auth/onboarding/'
       path: '/onboarding'
@@ -318,12 +337,14 @@ declare module '@tanstack/react-router' {
 }
 
 interface AppRouteChildren {
+  AppResearchThemesRoute: typeof AppResearchThemesRoute
   AppIndexRoute: typeof AppIndexRoute
   AppManageProfessorsRoute: typeof AppManageProfessorsRoute
   AppManageResearchThemesRoute: typeof AppManageResearchThemesRoute
 }
 
 const AppRouteChildren: AppRouteChildren = {
+  AppResearchThemesRoute: AppResearchThemesRoute,
   AppIndexRoute: AppIndexRoute,
   AppManageProfessorsRoute: AppManageProfessorsRoute,
   AppManageResearchThemesRoute: AppManageResearchThemesRoute,

--- a/frontend/src/routes/_app/research-themes.tsx
+++ b/frontend/src/routes/_app/research-themes.tsx
@@ -1,0 +1,32 @@
+import { ManagementPageLayout } from '@/components/layout/management-page-layout';
+import { ResearchThemesListing } from '@/features/research-themes/components/ResearchThemesListing';
+import { createFileRoute } from '@tanstack/react-router';
+
+function validateSearch(search: Record<string, unknown>): {
+  page: number;
+  search: string;
+  level: 'all' | 'masters' | 'doctoral';
+} {
+  return {
+    page: Math.max(1, Number(search.page) || 1),
+    search: typeof search.search === 'string' ? search.search : '',
+    level: (['masters', 'doctoral'] as const).includes(search.level as 'masters' | 'doctoral')
+      ? (search.level as 'masters' | 'doctoral')
+      : 'all',
+  };
+}
+
+export const Route = createFileRoute('/_app/research-themes')({
+  validateSearch,
+  component: ResearchThemesPage,
+});
+
+function ResearchThemesPage() {
+  const { page, search, level } = Route.useSearch();
+
+  return (
+    <ManagementPageLayout>
+      <ResearchThemesListing page={page} search={search} level={level} />
+    </ManagementPageLayout>
+  );
+}


### PR DESCRIPTION
Closes #75

## Summary
- Adds `/research-themes` route under `/_app` (auth-gated, any role)
- Read-only card listing: title, description, professor, vacancies, associated professors, level badge
- Zero-vacancy themes get a "Sem vagas" destructive badge
- Search by title/professor and level filter, state persisted in URL search params
- "Temas de Pesquisa" header nav link added for non-management roles (candidates, professors); management roles already have `/manage/research-themes`

## Test plan
- [ ] Log in as candidate → header shows "Temas de Pesquisa" link
- [ ] Log in as management role → link does NOT appear (use /manage/research-themes instead)
- [ ] `/research-themes` loads theme cards with title, description, professor name, vacancy count
- [ ] Theme with 0 vacancies shows "Sem vagas" badge
- [ ] Search by title filters results
- [ ] Search by professor name filters results
- [ ] Level filter (Mestrado/Doutorado) works
- [ ] Pagination works; page/search/level survive page reload (URL params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)